### PR TITLE
🔒 restrict all route access behind JWT verification

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -14,11 +14,21 @@ const PORT = process.env.PORT || 3000;
 app.use(bodyParser.json());
 app.use(cookieParser());
 
-app.get('/', user.checkSession);
+const singleStatic = (route, filePath) =>
+  app.get(route, (req, res) => {
+    res.sendFile(path.resolve(__dirname, '..', filePath));
+  });
+
+singleStatic('/login', 'client/login.html');
+singleStatic('/js/login.js', 'client/js/login.js');
+singleStatic('/css/login.css', 'client/css/login.css');
 
 // User Routes
 app.post('/signin', user.signIn, user.startSession);
 app.post('/signup', user.addUser, user.startSession);
+
+// Hide all other routes behind JWT validation
+app.use(user.checkSession);
 
 // Trip Routes
 app.get('/trips/:id', trips.getTrips);
@@ -30,7 +40,7 @@ app.get('/dest/:id', dest.getDestinations);
 app.post('/dest', dest.addDestination);
 app.delete('/dest', dest.deleteDestination);
 
-//List routes
+// List routes
 app.get('/list/:id', list.getListItems);
 app.post('/list', list.addListItem);
 app.delete('/list', list.deleteListItem);


### PR DESCRIPTION
The verification step assigns a user's id to `res.locals.id`, so that
will be accessible to all transactions (other than the login page).